### PR TITLE
Copy default pipe parameters value

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -17,6 +17,7 @@
 import logging
 import sys
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 
 from typing_extensions import Annotated, Any, NoDefault, get_args
 
@@ -112,11 +113,12 @@ class Pipe:
                     except KeyError:
                         if param.default is param.empty:
                             raise KeyError(f"{ann_name} node not found: '{ann.node}'")
-                        logger.debug(f"    using default value '{param.default}'")
-                        kwargs[name] = param.default
+                        logger.debug(f"    copying default value '{param.default}'")
+                        default = deepcopy(param.default)
                         if getattr(ann, "setdefault", False):
-                            logger.debug(f"    setting {ann_name} node '{ann.node}' to the default value")
-                            set_field(root, ann.node, param.default)
+                            logger.debug("    setting node to default value")
+                            set_field(root, ann.node, default)
+                        kwargs[name] = default
 
         if not dry_run or "dry_run" in kwargs:
             try:


### PR DESCRIPTION
There are good uses of mutable default arguments (see [0] and [1]) but none is allowed in pipes definitions because:

- pipes are components and shall not retain any state across invocations (no caching/memoization)

- pipes cannot be invoked in nested scopes

[0] https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments
[1] https://web.archive.org/web/20200605073004/http://effbot.org/zone/default-values.htm