### PR TITLE
Add `Pipe.Context` annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ pkg-test:
 	@$(foreach SRC,$(FORMATS), \
 		$(foreach DEST,$(FORMATS), \
 			echo "$(SRC) -> $(DEST)"; \
-			echo 'pipes: ["elastic.pipes.core.import": {"node": "documents", "file": "test/docs.$(SRC)"}, "elastic.pipes.core.export": {"node": "documents", "format": "$(DEST)"}]' | elastic-pipes run --log-level=debug - | [ "`$(TEE_STDERR)`" = "`cat test/docs.$(DEST)`" ] || exit 1; \
+			echo 'pipes: ["elastic.pipes.core.import": {"node@": "documents", "file": "test/docs.$(SRC)"}, "elastic.pipes.core.export": {"node@": "documents", "format": "$(DEST)"}]' | elastic-pipes run --log-level=debug - | [ "`$(TEE_STDERR)`" = "`cat test/docs.$(DEST)`" ] || exit 1; \
 		) \
 	)
 

--- a/core/runner.py
+++ b/core/runner.py
@@ -184,17 +184,19 @@ def new_pipe(
             f.write(
                 f"""#!/usr/bin/env python3
 
+from logging import Logger
+
 from elastic.pipes.core import Pipe
 from typing_extensions import Annotated
 
 
 @Pipe("{pipe_file.stem}", default={{}})
 def main(
-    pipe: Pipe,
-    dry_run: bool = False,
+    log: Logger,
     name: Annotated[str, Pipe.State("name")] = "world",
+    dry_run: bool = False,
 ):
-    pipe.logger.info(f"Hello, {{name}}!")
+    log.info(f"Hello, {{name}}!")
 
 
 if __name__ == "__main__":

--- a/core/util.py
+++ b/core/util.py
@@ -92,25 +92,26 @@ def has_node(dict, path):
     return dict
 
 
-def get_node(dict, path, default=NoDefault, *, shell_expand=False):
+def get_node(dict, path, default=NoDefault, *, default_action=None, shell_expand=False):
+    if default_action is None:
+
+        def default_action():
+            if default is NoDefault:
+                raise KeyError(path)
+            return default
+
     keys = split_path(path)
     for i, key in enumerate(keys):
         if dict is None:
-            if default == NoDefault:
-                raise KeyError(path)
-            return default
+            return default_action()
         if not isinstance(dict, Mapping):
             raise Error(f"not an object: {'.'.join(keys[:i])} (type is {type(dict).__name__})")
         try:
             dict = dict[key]
         except KeyError:
-            if default == NoDefault:
-                raise KeyError(path)
-            return default
+            return default_action()
     if dict is None:
-        if default == NoDefault:
-            raise KeyError(path)
-        return default
+        return default_action()
     if shell_expand:
         from .shelllib import shell_expand
 

--- a/hcp/vault/test.yaml
+++ b/hcp/vault/test.yaml
@@ -2,19 +2,19 @@
 
 pipes:
   - elastic.pipes.core.import:
-      node: secret-in.data
+      node@: secret-in.data
   - elastic.pipes.hcp.vault.write:
       url: http://localhost:8200
       # get token from environment variable
       path: secret/data/test
-      vault: secret-in
+      vault@: secret-in
   - elastic.pipes.hcp.vault.read:
       # get url from environment variable
       token: test
       path: secret/data/test
-      vault: secret-out
+      vault@: secret-out
   - elastic.pipes.core.export:
-      node: secret-out.data
+      node@: secret-out.data
 
 secret-in: {}
 secret-out: {}


### PR DESCRIPTION
Open up annotation possibilities, allow defining bindings to config and state in a more flexible way, out of the function parameters list.

Append `@` to the config fields to redirect to state nodes.