### PR TITLE
Drop Pipe.State setdefault

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 from typing_extensions import Annotated, Any, NoDefault, get_args
 
 from .errors import ConfigError, Error
-from .util import get_node, set_node
+from .util import get_node
 
 __version__ = "0.5.0-dev"
 
@@ -128,9 +128,6 @@ class Pipe:
                             raise KeyError(f"{ann_name} node not found: '{node}'")
                         logger.debug(f"    copying default value '{param.default}'")
                         default = deepcopy(param.default)
-                        if getattr(ann, "setdefault", False):
-                            logger.debug("    setting node to default value")
-                            set_node(root, node, default)
                         kwargs[name] = default
 
         if not dry_run or "dry_run" in kwargs:
@@ -165,9 +162,8 @@ class Pipe:
         pass
 
     class State(Node):
-        def __init__(self, node, *, setdefault=False, indirect=True):
+        def __init__(self, node, *, indirect=True):
             super().__init__(node)
-            self.setdefault = setdefault
             self.indirect = indirect
 
 

--- a/test/test_pipe.py
+++ b/test/test_pipe.py
@@ -194,30 +194,6 @@ def test_state_indirect():
     Pipe.find("test_state_indirect_them").run({"user": "username"}, {"name": "us", "username": "them"}, False, logger)
 
 
-def test_state_setdefault():
-    state = {}
-
-    @Pipe("test_state_no_setdefault")
-    def _(
-        pipe: Pipe,
-        names: Annotated[str, Pipe.State("names")] = [],
-    ):
-        names.extend(["me", "you"])
-
-    @Pipe("test_state_setdefault")
-    def _(
-        pipe: Pipe,
-        names: Annotated[str, Pipe.State("names", setdefault=True)] = [],
-    ):
-        names.extend(["me", "you"])
-
-    Pipe.find("test_state_no_setdefault").run({}, state, False, logger)
-    assert state == {}
-
-    Pipe.find("test_state_setdefault").run({}, state, False, logger)
-    assert state == {"names": ["me", "you"]}
-
-
 def test_get_pipes():
     state = None
     pipes = get_pipes(state)


### PR DESCRIPTION
Let's keep things simple: state nodes for update need to exist.
Encourage having them in the configuration, possibly with good comments.
Explicit is better than explicit.