### PR TITLE
Support @-keyed dict assembly in Mapping-typed pipe params

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -118,7 +118,8 @@ class Pipe:
         for node, type_, *_ in walk_params(self):
             if isinstance(node, Pipe.Config):
                 yield node.node, type_
-                yield node.get_indirect_node_name(), str
+                if indirect := node.get_indirect_node_name():
+                    yield indirect, str
             elif isinstance(node, Pipe.State):
                 if indirect := node.get_indirect_node_name():
                     yield indirect, str
@@ -246,15 +247,20 @@ class Pipe:
             pass
 
     class Config(Node):
+        def __init__(self, node, *, indirect=True):
+            super().__init__(node)
+            self.indirect = indirect
+
         def get_indirect_node_name(self):
-            return _indirect(self.node)
+            if self.indirect:
+                return _indirect(self.node if self.indirect is True else self.indirect)
 
         def handle_param(self, param, config, state, core_logger):
             if param.default is not param.empty and is_mutable(param.default):
                 raise TypeError(f"param '{param.name}': mutable default not allowed: {param.default}")
             indirect = self.get_indirect_node_name()
             has_value = has_node(config, self.node)
-            has_indirect = has_node(config, indirect)
+            has_indirect = indirect and has_node(config, indirect)
             if has_value and has_indirect:
                 raise ConfigError(f"param '{param.name}': config cannot specify both '{self.node}' and '{indirect}'")
             binding = Pipe.Node.Binding()
@@ -289,7 +295,8 @@ class Pipe:
                     binding.root = config
                     binding.root_name = "config"
                     core_logger.debug(f"  re-bind param '{param.name}' to {binding.root_name} node '{binding.node}'")
-                    config.pop(indirect)
+                    if indirect:
+                        config.pop(indirect)
                 set_node(binding.root, binding.node, value)
 
             return binding, getter, setter

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -123,6 +123,8 @@ class Pipe:
             elif isinstance(node, Pipe.State):
                 if indirect := node.get_indirect_node_name():
                     yield indirect, str
+                if node.node is not None and (type_ is Any or (isinstance(type_, type) and issubclass(type_, Mapping))):
+                    yield node.node, type_
 
     def check_config(self, config, core_logger):
         from .util import split_path, walk_tree
@@ -138,7 +140,11 @@ class Pipe:
                 param_path = split_path(param)
                 if node_path == param_path:
                     break
-                if issubclass(type_, Mapping) and len(param_path) < len(node_path) and all(a == b for a, b in zip(param_path, node_path)):
+                if (
+                    (type_ is Any or (isinstance(type_, type) and issubclass(type_, Mapping)))
+                    and len(param_path) < len(node_path)
+                    and all(a == b for a, b in zip(param_path, node_path))
+                ):
                     break
             else:
                 unknown.add(".".join(node_path))
@@ -259,20 +265,36 @@ class Pipe:
             if param.default is not param.empty and is_mutable(param.default):
                 raise TypeError(f"param '{param.name}': mutable default not allowed: {param.default}")
             indirect = self.get_indirect_node_name()
-            has_value = has_node(config, self.node)
-            has_indirect = indirect and has_node(config, indirect)
-            if has_value and has_indirect:
-                raise ConfigError(f"param '{param.name}': config cannot specify both '{self.node}' and '{indirect}'")
+
             binding = Pipe.Node.Binding()
-            if has_indirect:
-                binding.node = get_node(config, indirect)
-                binding.root = state
-                binding.root_name = "state"
-            else:
-                binding.node = self.node
+            binding.node = self.node
+            binding.assembly_config = None
+            binding.root = None
+
+            if has_node(config, self.node):
+                if indirect and has_node(config, indirect):
+                    raise ConfigError(f"param '{param.name}': config cannot specify both '{self.node}' and '{indirect}'")
+                value = get_node(config, self.node)
+                if isinstance(value, Mapping):
+                    if any(isinstance(k, str) and k.endswith("@") for k in value):
+                        binding.assembly_config = value
+                        core_logger.debug(f"  bind param '{param.name}' to assembled dict from config node '{self.node}'")
+                    else:
+                        core_logger.debug(f"  bind param '{param.name}' to literal dict from config node '{self.node}'")
                 binding.root = config
                 binding.root_name = "config"
-            core_logger.debug(f"  bind param '{param.name}' to {binding.root_name} node '{binding.node}'")
+
+            if indirect:
+                if binding.root is None and has_node(config, indirect):
+                    binding.node = get_node(config, indirect)
+                    binding.root = state
+                    binding.root_name = "state"
+                    core_logger.debug(f"  bind param '{param.name}' to state node '{binding.node}'")
+
+            if binding.root is None:
+                binding.root = config
+                binding.root_name = "config"
+                core_logger.debug(f"  bind param '{param.name}' to config node '{self.node}'")
 
             def default_action():
                 if param.default is param.empty:
@@ -280,7 +302,18 @@ class Pipe:
                 return param.default
 
             def getter(_):
-                value = get_node(binding.root, binding.node, default_action=default_action)
+                if binding.assembly_config is None:
+                    value = get_node(binding.root, binding.node, default_action=default_action)
+                else:
+                    value = {}
+                    for k, v in binding.assembly_config.items():
+                        if k.endswith("@"):
+                            try:
+                                value[k[:-1]] = get_node(state, v)
+                            except KeyError:
+                                raise KeyError(f"param '{param.name}': state node not found: '{v}'")
+                        else:
+                            value[k] = v
                 if value is None or param.type is Any or isinstance(value, param.type):
                     return value
                 value_type = type(value).__name__
@@ -297,6 +330,7 @@ class Pipe:
                     core_logger.debug(f"  re-bind param '{param.name}' to {binding.root_name} node '{binding.node}'")
                     if indirect:
                         config.pop(indirect)
+                binding.assembly_config = None
                 set_node(binding.root, binding.node, value)
 
             return binding, getter, setter
@@ -319,17 +353,39 @@ class Pipe:
             if param.default is not param.empty and is_mutable(param.default):
                 raise TypeError(f"param '{param.name}': mutable default not allowed: {param.default}")
             node = self.node
-            if indirect := self.get_indirect_node_name():
-                node = get_node(config, indirect, node)
-            if node is None:
-                core_logger.debug(f"  bind param '{param.name}' to the whole state")
-            else:
-                core_logger.debug(f"  bind param '{param.name}' to state node '{node}'")
+            indirect = self.get_indirect_node_name()
 
             binding = Pipe.Node.Binding()
             binding.node = node
-            binding.root = state
-            binding.root_name = "state"
+            binding.assembly_config = None
+            binding.root = None
+
+            if node is not None and has_node(config, node):
+                if indirect and has_node(config, indirect):
+                    raise ConfigError(f"param '{param.name}': config cannot specify both '{node}' and '{indirect}'")
+                value = get_node(config, node, None)
+                if not isinstance(value, Mapping):
+                    raise ConfigError(f"param '{param.name}': config node '{node}' must be a mapping")
+                if any(isinstance(k, str) and k.endswith("@") for k in value):
+                    binding.assembly_config = value
+                    core_logger.debug(f"  bind param '{param.name}' to assembled dict from config node '{node}'")
+                else:
+                    core_logger.debug(f"  bind param '{param.name}' to literal dict from config node '{node}'")
+                binding.root = config
+                binding.root_name = "config"
+
+            if indirect:
+                if binding.root is None:
+                    node = get_node(config, indirect, node)
+                    binding.node = node
+
+            if binding.root is None:
+                binding.root = state
+                binding.root_name = "state"
+                if node is None:
+                    core_logger.debug(f"  bind param '{param.name}' to the whole state")
+                else:
+                    core_logger.debug(f"  bind param '{param.name}' to state node '{node}'")
 
             def default_action():
                 if param.default is param.empty:
@@ -337,7 +393,18 @@ class Pipe:
                 return param.default
 
             def getter(_):
-                value = get_node(binding.root, binding.node, default_action=default_action)
+                if binding.assembly_config is None:
+                    value = get_node(binding.root, binding.node, default_action=default_action)
+                else:
+                    value = {}
+                    for k, v in binding.assembly_config.items():
+                        if k.endswith("@"):
+                            try:
+                                value[k[:-1]] = get_node(state, v)
+                            except KeyError:
+                                raise KeyError(f"param '{param.name}': state node not found: '{v}'")
+                        else:
+                            value[k] = v
                 if value is not None and is_mutable(value) and not self.mutable:
                     raise AttributeError(f"param '{param.name}' is mutable but not marked as such")
                 if value is None or param.type is Any or isinstance(value, param.type):
@@ -351,12 +418,12 @@ class Pipe:
             def setter(_, value):
                 if not self.mutable:
                     raise AttributeError(f"param '{param.name}' is not mutable")
-
                 if binding.node != node or binding.root is not state or binding.root_name != "state":
                     binding.node = node
                     binding.root = state
                     binding.root_name = "state"
                     core_logger.debug(f"  re-bind param '{param.name}' to {binding.root_name} node '{binding.node}'")
+                binding.assembly_config = None
                 set_node(binding.root, binding.node, value)
 
             return binding, getter, setter

--- a/core/export.py
+++ b/core/export.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing_extensions import Annotated, Any
 
 from . import Pipe
+from .errors import ConfigError
 from .util import serialize
 
 
@@ -44,11 +45,21 @@ class Ctx(Pipe.Context):
         Pipe.Help("state node containing the source data"),
         Pipe.Notes("default: whole state"),
     ]
+    data: Annotated[
+        dict,
+        Pipe.Config("data", indirect=False),
+        Pipe.Help("assembled data to export; keys suffixed with [bold green]@[/bold green] are resolved from state"),
+        Pipe.Notes("default: state node referenced by 'node@', or whole state"),
+    ] = None
     on_failure: Annotated[
         bool,
         Pipe.Config("on-failure"),
         Pipe.Help("export data only when the pipe script has failed"),
     ] = False
+
+    def __init__(self):
+        if self.data is not None and self.get_binding("state").node is not None:
+            raise ConfigError("param 'data' and 'node@' cannot both be specified")
 
 
 @Pipe()
@@ -68,8 +79,14 @@ def main(ctx: Ctx, log: Logger, stack: ExitStack, dry_run: bool):
         if ctx.on_failure and exc_type is None:
             return
 
-        node = ctx.get_binding("state").node
-        msg_state = "everything" if node is None else f"'{node}'"
+        if ctx.data is not None:
+            msg_state = "'data'"
+            exported = ctx.data
+        else:
+            node = ctx.get_binding("state").node
+            msg_state = "everything" if node is None else f"'{node}'"
+            exported = ctx.state
+
         msg_file_name = f"'{ctx.file_name}'" if ctx.file_name else "standard output"
         on_failure = " due to script failure" if ctx.on_failure else ""
 
@@ -81,9 +98,9 @@ def main(ctx: Ctx, log: Logger, stack: ExitStack, dry_run: bool):
 
         if ctx.file_name:
             with Path(ctx.file_name).expanduser().open("w") as f:
-                serialize(f, ctx.state, format=format)
+                serialize(f, exported, format=format)
         else:
-            serialize(sys.stdout, ctx.state, format=format)
+            serialize(sys.stdout, exported, format=format)
 
     if ctx.on_failure:
         log.info("deferring until any script failure...")

--- a/core/util.py
+++ b/core/util.py
@@ -351,8 +351,8 @@ def walk_config_nodes(pipes, prefix):
 
     for pipe, config in pipes:
         for node, _type, help, notes, default, empty in walk_params(pipe):
-            if isinstance(node, Pipe.Config):
-                indirect = node.node
+            if isinstance(node, Pipe.Config) and node.indirect:
+                indirect = node.node if node.indirect is True else node.indirect
                 if arg_name := _get_name(config, indirect):
                     yield pipe, "config", node, help, notes, _type, indirect, arg_name
             elif isinstance(node, Pipe.State) and node.indirect:

--- a/core/util.py
+++ b/core/util.py
@@ -19,7 +19,7 @@ import re
 import sys
 from collections.abc import Mapping
 
-from typing_extensions import NoDefault, get_args
+from typing_extensions import Any, NoDefault, get_args
 
 from .errors import ConfigError, Error
 
@@ -98,7 +98,7 @@ def has_node(dict, path):
             dict = dict[key]
         except KeyError:
             return False
-    return dict
+    return dict is not None
 
 
 def get_node(dict, path, default=NoDefault, *, default_action=None, shell_expand=False):
@@ -346,19 +346,36 @@ def walk_config_nodes(pipes, prefix):
     def _get_name(config, indirect):
         if has_node(config, _indirect(indirect)):
             node = get_node(config, _indirect(indirect))
-            if node.startswith(prefix):
+            if isinstance(node, str) and node.startswith(prefix):
                 return node
+
+    def _scan_assembled(config, param_node):
+        """Yield (key_name, arg_name) for @-keyed entries in an assembled dict whose values start with prefix."""
+        if param_node is None:
+            return
+        config_val = get_node(config, param_node, None)
+        if not isinstance(config_val, Mapping):
+            return
+        for k, v in config_val.items():
+            if k.endswith("@") and isinstance(v, str) and v.startswith(prefix):
+                yield f"{param_node}.{k}", v
 
     for pipe, config in pipes:
         for node, _type, help, notes, default, empty in walk_params(pipe):
-            if isinstance(node, Pipe.Config) and node.indirect:
-                indirect = node.node if node.indirect is True else node.indirect
-                if arg_name := _get_name(config, indirect):
-                    yield pipe, "config", node, help, notes, _type, indirect, arg_name
-            elif isinstance(node, Pipe.State) and node.indirect:
-                indirect = node.node if node.indirect is True else node.indirect
-                if arg_name := _get_name(config, indirect):
-                    yield pipe, "state", node, help, notes, _type, indirect, arg_name
+            if isinstance(node, Pipe.Config):
+                if node.indirect:
+                    indirect = node.node if node.indirect is True else node.indirect
+                    if arg_name := _get_name(config, indirect):
+                        yield pipe, "config", node, help, notes, _type, indirect, arg_name
+                for key_name, arg_name in _scan_assembled(config, node.node):
+                    yield pipe, "config", node, help, notes, Any, key_name, arg_name
+            elif isinstance(node, Pipe.State):
+                if node.indirect:
+                    indirect = node.node if node.indirect is True else node.indirect
+                    if arg_name := _get_name(config, indirect):
+                        yield pipe, "state", node, help, notes, _type, indirect, arg_name
+                for key_name, arg_name in _scan_assembled(config, node.node):
+                    yield pipe, "state", node, help, notes, Any, key_name, arg_name
 
 
 def walk_args_env(pipes, args_env):

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -150,3 +150,26 @@ def test_export_on_failure_export_on_failure():
     finally:
         if os.path.exists(filename):
             os.unlink(filename)
+
+
+def test_export_data():
+    import io
+
+    old_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        config = {
+            "data": {
+                "api_key@": "creds.key",
+                "email": "literal@example.com",
+            }
+        }
+        state = {"creds": {"key": "abc"}}
+        with run("core.export", config, state):
+            pass
+        sys.stdout.flush()
+        result = deserialize(io.StringIO(sys.stdout.getvalue()), format="yaml")
+    finally:
+        sys.stdout = old_stdout
+
+    assert result == {"api_key": "abc", "email": "literal@example.com"}

--- a/test/test_pipe.py
+++ b/test/test_pipe.py
@@ -415,6 +415,131 @@ def test_state_indirect():
     run("test_state_indirect_them", {"user@": "username"}, {"name": "us", "username": "them"})
 
 
+def test_state_dict_assembly():
+    @Pipe("test_state_assembly_basic")
+    def _(
+        data: Annotated[dict, Pipe.State("data", mutable=True)],
+    ):
+        assert data == {"api_key": "abc", "email": "x@y.com"}
+
+    run(
+        "test_state_assembly_basic",
+        {"data": {"api_key@": "creds.key", "email@": "creds.email"}},
+        {"creds": {"key": "abc", "email": "x@y.com"}},
+    )
+
+    @Pipe("test_state_assembly_mixed")
+    def _(
+        data: Annotated[dict, Pipe.State("data", mutable=True)],
+    ):
+        assert data == {"api_key": "abc", "email": "hardcoded@example.com"}
+
+    run(
+        "test_state_assembly_mixed",
+        {"data": {"api_key@": "creds.key", "email": "hardcoded@example.com"}},
+        {"creds": {"key": "abc"}},
+    )
+
+    @Pipe("test_state_assembly_literal_only")
+    def _(
+        data: Annotated[dict, Pipe.State("data", mutable=True)],
+    ):
+        assert data == {"email": "literal@example.com", "role": "admin"}
+
+    run(
+        "test_state_assembly_literal_only",
+        {"data": {"email": "literal@example.com", "role": "admin"}},
+        {},
+    )
+
+    @Pipe("test_state_assembly_conflict")
+    def _(
+        data: Annotated[dict, Pipe.State("data", mutable=True)],
+    ):
+        pass
+
+    msg = "param 'data': config cannot specify both 'data' and 'data@'"
+    with pytest.raises(ConfigError, match=msg):
+        run(
+            "test_state_assembly_conflict",
+            {"data": {"api_key@": "creds.key"}, "data@": "other"},
+            {"creds": {"key": "abc"}, "other": {}},
+        )
+
+    with pytest.raises(ConfigError, match=msg):
+        run(
+            "test_state_assembly_conflict",
+            {"data": ["bad"], "data@": "other"},
+            {"other": {}},
+        )
+
+    @Pipe("test_state_assembly_check_config")
+    def _(
+        data: Annotated[dict, Pipe.State("data", mutable=True)],
+    ):
+        pass
+
+    msg = "unknown config node: 'other.api_key@'"
+    with pytest.raises(Error, match=msg):
+        run("test_state_assembly_check_config", {"other": {"api_key@": "creds.key"}}, {})
+
+    class DataCtx(Pipe.Context):
+        data: Annotated[dict, Pipe.State("data", mutable=True)]
+
+    @Pipe("test_state_assembly_ctx_set")
+    def _(ctx: DataCtx):
+        assert ctx.data == {"api_key": "abc"}
+        ctx.data = {"api_key": "xyz"}
+        # subsequent read returns the value written to state
+        assert ctx.data == {"api_key": "xyz"}
+
+    run(
+        "test_state_assembly_ctx_set",
+        {"data": {"api_key@": "creds.key"}},
+        {"creds": {"key": "abc"}},
+    )
+
+
+def test_config_dict_assembly():
+    @Pipe("test_config_assembly_basic")
+    def _(
+        data: Annotated[dict, Pipe.Config("data")],
+    ):
+        assert data == {"api_key": "abc", "email": "x@y.com"}
+
+    run(
+        "test_config_assembly_basic",
+        {"data": {"api_key@": "creds.key", "email@": "creds.email"}},
+        {"creds": {"key": "abc", "email": "x@y.com"}},
+    )
+
+    @Pipe("test_config_assembly_mixed")
+    def _(
+        data: Annotated[dict, Pipe.Config("data")],
+    ):
+        assert data == {"api_key": "abc", "email": "hardcoded@example.com"}
+
+    run(
+        "test_config_assembly_mixed",
+        {"data": {"api_key@": "creds.key", "email": "hardcoded@example.com"}},
+        {"creds": {"key": "abc"}},
+    )
+
+
+def test_config_indirect_false_assembly():
+    @Pipe("test_config_indirect_false_assembly")
+    def _(
+        data: Annotated[dict, Pipe.Config("data", indirect=False)],
+    ):
+        assert data == {"api_key": "abc", "email": "x@y.com"}
+
+    run(
+        "test_config_indirect_false_assembly",
+        {"data": {"api_key@": "creds.key", "email@": "creds.email"}},
+        {"creds": {"key": "abc", "email": "x@y.com"}},
+    )
+
+
 def test_get_pipes():
     state = None
     pipes = get_pipes(state)

--- a/test/test_pipe.py
+++ b/test/test_pipe.py
@@ -178,6 +178,26 @@ def test_config_unknown():
         run("test_config_unknown", {"names@": "others"}, {})
 
 
+def test_config_indirect_false():
+    @Pipe("test_config_indirect_false_basic")
+    def _(
+        data: Annotated[str, Pipe.Config("data", indirect=False)],
+    ):
+        assert data == "hello"
+
+    # direct value works
+    run("test_config_indirect_false_basic", {"data": "hello"}, {})
+
+    # data@ is rejected by check_config
+    msg = "unknown config node: 'data@'"
+    with pytest.raises(Error, match=msg):
+        run(
+            "test_config_indirect_false_basic",
+            {"data@": "some.path"},
+            {"some": {"path": "hello"}},
+        )
+
+
 def test_state():
     @Pipe("test_state")
     def _(

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -204,3 +204,55 @@ def test_runtime_environment(tc):
                 assert state["runtime"]["environment"] == tc.exp
             else:
                 assert "environment" not in state["runtime"]
+
+
+def test_runtime_arguments_assembled():
+    @TestPipe
+    def _fn(
+        creds: Annotated[dict, Pipe.Config("creds", indirect=False)],
+    ):
+        assert creds == {"api_key": "secret", "email": "static@example.com"}
+
+    config = {"creds": {"api_key@": "runtime.arguments.API_KEY", "email": "static@example.com"}}
+
+    with _fn(config, {"runtime": {"arguments": {}}}, arguments=["API_KEY=secret"]) as state:
+        assert state["runtime"]["arguments"] == {"API_KEY": "secret"}
+
+
+def test_runtime_environment_assembled():
+    @TestPipe
+    def _fn(
+        creds: Annotated[dict, Pipe.Config("creds", indirect=False)],
+    ):
+        assert creds == {"api_key": "secret"}
+
+    config = {"creds": {"api_key@": "runtime.environment.API_KEY"}}
+
+    with _fn(config, {"runtime": {"environment": {}}}, environment={"API_KEY": "secret"}) as state:
+        assert state["runtime"]["environment"] == {"API_KEY": "secret"}
+
+
+def test_runtime_assembled_literal_eval():
+    @TestPipe
+    def _fn(
+        opts: Annotated[dict, Pipe.Config("opts", indirect=False)],
+    ):
+        assert opts == {"count": 42, "tags": ("a", "b"), "name": "hello"}
+
+    config = {"opts": {"count@": "runtime.arguments.COUNT", "tags@": "runtime.arguments.TAGS", "name@": "runtime.arguments.NAME"}}
+
+    with _fn(config, {}, arguments=["COUNT=42", "TAGS=('a', 'b')", "NAME=hello"]) as state:
+        assert state["runtime"]["arguments"] == {"COUNT": 42, "TAGS": ("a", "b"), "NAME": "hello"}
+
+
+def test_runtime_arguments_assembled_state():
+    @TestPipe
+    def _fn(
+        creds: Annotated[dict, Pipe.State("creds", mutable=True)],
+    ):
+        assert creds == {"api_key": "secret", "email": "static@example.com"}
+
+    config = {"creds": {"api_key@": "runtime.arguments.API_KEY", "email": "static@example.com"}}
+
+    with _fn(config, {}, arguments=["API_KEY=secret"]) as state:
+        assert state["runtime"]["arguments"] == {"API_KEY": "secret"}

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -66,7 +66,7 @@ def test_has_node():
     assert not has_node(d, "name.nick")
 
     assert has_node(d, None)
-    assert not has_node({}, None)
+    assert has_node({}, None)
     assert not has_node(None, None)
 
 


### PR DESCRIPTION
## Motivation

It is currently possible to redirect an entire `Pipe.State` node to a different state path using the `@` indirection syntax (e.g. `vault@: some.state.path`). But there is no way to _assemble_ a dict from individual state values inline in the config.

This PR adds that capability. When a `Pipe.State` or `Pipe.Config` parameter has a `Mapping` (dict) type and its config node contains a dict with `@`-suffixed keys, those keys are resolved from state at runtime and assembled into the final dict. Non-`@` keys are passed through as literal values. The pipe itself requires no changes.

## Example

Using the export pipe&#39;s new `data` config node:

```yaml
- elastic.pipes.core.export:
    data:
      api_key@: myproject.credentials.api_key
      email:    literal@example.com
```

`elastic.pipes.core.export` receives `data` as `{&#34;api_key&#34;: <state value of myproject.credentials.api_key>, &#34;email&#34;: &#34;literal@example.com&#34;}` with no changes to its signature.

## Commits

1. **Make indirection optional in `Pipe.Config`** — adds an `indirect` keyword argument (default `True`); when `False`, `foo@` is neither registered nor accepted by `check_config`.

2. **Add `data` config node to the export pipe** — optional `Pipe.Config(&#34;data&#34;, indirect=False)` param; when set as a dict, its `@`-keyed entries are resolved from state and the assembled result is exported directly. Specifying both `data` and `node@` is a `ConfigError` detected in `Ctx.__init__`. Falls back to the existing `node@`/whole-state behaviour when absent.

3. **Support `@`-keyed dict assembly from state in Mapping-typed params** — the assembly mechanism itself, for both `Pipe.State` and `Pipe.Config`:
   - `Pipe.State`: assembly mode is detected when a `Mapping` is present at the param&#39;s config node name. `@`-keys are resolved from state at getter call time. After a setter call the value lives in state and subsequent reads bypass assembly (tracked via `binding.root`). Specifying both `vault: {...}` and `vault@: ...` is a `ConfigError`. The `check_config` `issubclass` call is guarded against `Any` to avoid a `TypeError`.
   - `Pipe.Config`: assembly is applied transparently in the getter whenever the resolved value is a `Mapping` containing any `@`-keyed entry, and only when the value comes directly from config (not when indirection has already rebound the root to state).
   - `walk_config_nodes` gains a `_scan_assembled` helper that discovers `runtime.*` references inside assembled-dict values, so `--explain` and arg/env discovery work for inlined `@`-keyed entries.
   - `has_node` now returns `dict is not None` — a `None` leaf is treated as absent (consistent with `get_node` semantics), while any other value including falsy ones (`{}`, `[]`, `0`, `False`, `""`) is treated as present.