### PR TITLE
Add bearer_auth support to ES and Kibana clients

### DIFF
--- a/core/kibana.py
+++ b/core/kibana.py
@@ -25,7 +25,7 @@ class Kibana:
 
     exceptions = requests.exceptions
 
-    def __init__(self, url=None, cloud_id=None, basic_auth=None, api_key=None, verify_certs=True, ca_certs=None):
+    def __init__(self, url=None, cloud_id=None, basic_auth=None, api_key=None, bearer_auth=None, verify_certs=True, ca_certs=None):
         if not (url or cloud_id):
             raise ValueError("Either `url` or `cloud_id` must be defined")
 
@@ -35,6 +35,8 @@ class Kibana:
 
         if api_key:
             self.session.headers["Authorization"] = f"ApiKey {api_key}"
+        elif bearer_auth:
+            self.session.headers["Authorization"] = f"Bearer {bearer_auth}"
         if basic_auth:
             self.session.auth = requests.auth.HTTPBasicAuth(*basic_auth)
         if not verify_certs:

--- a/core/util.py
+++ b/core/util.py
@@ -47,6 +47,7 @@ def get_es_client(stack):
 
     shell_expand = get_node(stack, "shell-expand", False)
     api_key = get_node(stack, "credentials.api-key", None, shell_expand=shell_expand)
+    token = get_node(stack, "credentials.token", None, shell_expand=shell_expand)
     username = get_node(stack, "credentials.username", None, shell_expand=shell_expand)
     password = get_node(stack, "credentials.password", None, shell_expand=shell_expand)
 
@@ -55,6 +56,8 @@ def get_es_client(stack):
     }
     if api_key:
         args["api_key"] = api_key
+    elif token:
+        args["bearer_auth"] = token
     elif username:
         args["basic_auth"] = (username, password)
     return Elasticsearch(**args)
@@ -65,6 +68,7 @@ def get_kb_client(stack):
 
     shell_expand = get_node(stack, "shell-expand", False)
     api_key = get_node(stack, "credentials.api-key", None, shell_expand=shell_expand)
+    token = get_node(stack, "credentials.token", None, shell_expand=shell_expand)
     username = get_node(stack, "credentials.username", None, shell_expand=shell_expand)
     password = get_node(stack, "credentials.password", None, shell_expand=shell_expand)
 
@@ -73,6 +77,8 @@ def get_kb_client(stack):
     }
     if api_key:
         args["api_key"] = api_key
+    elif token:
+        args["bearer_auth"] = token
     elif username:
         args["basic_auth"] = (username, password)
     return Kibana(**args)


### PR DESCRIPTION
## Summary

`get_es_client` and `get_kb_client` only supported `api_key` and `basic_auth`. This adds a third path reading `credentials.token` from the stack state and passing it as `bearer_auth`, enabling SSO token-based authentication without API keys.

This is a prerequisite for the `oauth2/login` pipe in `pipes-py`, which authenticates to Elasticsearch via Okta SSO (OAuth2 device flow → SAML → ES access token) and writes the resulting token to `stack.credentials.token`.