### PR TITLE
Fix all ruff lint violations so `make lint` passes

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 """Core definitions for creating Elastic Pipes components."""
-
 import logging
 import sys
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from collections.abc import Mapping, Sequence
 from contextlib import ExitStack
+from typing import ClassVar
 
 from typing_extensions import Annotated, Any, NoDefault, get_args
 
@@ -79,7 +79,7 @@ def _get_name_from_func(func):
 
 
 class Pipe:
-    __pipes__ = {}
+    __pipes__: ClassVar[dict] = {}
 
     def __init__(self, name=None, *, default=sys.exit, notes=None, closing_notes=None):
         self.func = None
@@ -132,7 +132,7 @@ class Pipe:
         core_logger.debug(f"checking configuration '{self.name}'...")
 
         params = list(self._walk_config_params())
-        nodes = list(path for path, _ in walk_tree(config))
+        nodes = [path for path, _ in walk_tree(config)]
 
         unknown = set()
         for node_path in nodes:
@@ -230,7 +230,7 @@ class Pipe:
                         except KeyError as e:
                             raise Error(e.args[0])
 
-            setattr(sub, "__pipe_ctx_bindings__", bindings)
+            sub.__pipe_ctx_bindings__ = bindings
             return stack.enter_context(sub())
 
         @classmethod
@@ -284,12 +284,11 @@ class Pipe:
                 binding.root = config
                 binding.root_name = "config"
 
-            if indirect:
-                if binding.root is None and has_node(config, indirect):
-                    binding.node = get_node(config, indirect)
-                    binding.root = state
-                    binding.root_name = "state"
-                    core_logger.debug(f"  bind param '{param.name}' to state node '{binding.node}'")
+            if indirect and binding.root is None and has_node(config, indirect):
+                binding.node = get_node(config, indirect)
+                binding.root = state
+                binding.root_name = "state"
+                core_logger.debug(f"  bind param '{param.name}' to state node '{binding.node}'")
 
             if binding.root is None:
                 binding.root = config
@@ -374,10 +373,9 @@ class Pipe:
                 binding.root = config
                 binding.root_name = "config"
 
-            if indirect:
-                if binding.root is None:
-                    node = get_node(config, indirect, node)
-                    binding.node = node
+            if indirect and binding.root is None:
+                node = get_node(config, indirect, node)
+                binding.node = node
 
             if binding.root is None:
                 binding.root = state

--- a/core/kibana.py
+++ b/core/kibana.py
@@ -54,8 +54,8 @@ class Kibana:
         if cloud_id:
             import base64
 
-            cluster_name, cloud_info = cloud_id.split(":")
-            domain, es_uuid, kibana_uuid = base64.b64decode(cloud_info.encode("utf-8")).decode("utf-8").split("$")
+            _cluster_name, cloud_info = cloud_id.split(":")
+            domain, _es_uuid, kibana_uuid = base64.b64decode(cloud_info.encode("utf-8")).decode("utf-8").split("$")
 
             if domain.endswith(":443"):
                 domain = domain[:-4]

--- a/core/runner.py
+++ b/core/runner.py
@@ -18,9 +18,10 @@ import os
 import sys
 from contextlib import ExitStack
 from pathlib import Path
+from typing import List, Optional
 
 import typer
-from typing_extensions import Annotated, List, Optional
+from typing_extensions import Annotated
 
 from .util import fatal, get_node, setup_logging
 
@@ -44,7 +45,7 @@ def configure_runtime_args_env(runtime, args_env, values, pipes, logger):
             if type is not str:
                 try:
                     value = ast.literal_eval(value)
-                except Exception:
+                except (ValueError, SyntaxError):
                     pass
             logger.debug(f"  {name}: {value}")
             set_node(runtime.setdefault(args_env, {}), name, value)
@@ -159,7 +160,7 @@ def run(
     config_file: typer.FileText,
     dry_run: Annotated[bool, typer.Option()] = False,
     explain: Annotated[bool, typer.Option(help="Describe what the script does.")] = False,
-    log_level: Annotated[str, typer.Option(callback=setup_logging("INFO"))] = None,
+    log_level: Annotated[Optional[str], typer.Option(callback=setup_logging("INFO"))] = None,
     arguments: Annotated[Optional[List[str]], typer.Option("--argument", "-a", help="Pass an argument to the Pipes runtime.")] = None,
 ):
     """

--- a/core/shelllib.py
+++ b/core/shelllib.py
@@ -29,7 +29,7 @@ _re_escaped_slash = re.compile(r"\\\\")
 
 def _repl_subshell(match):
     command = match.group(1)
-    p = subprocess.run(command, stdout=subprocess.PIPE, shell=True, text=True)
+    p = subprocess.run(command, stdout=subprocess.PIPE, shell=True, text=True, check=False)
     if p.returncode:
         raise ShellExpansionError(f"Command '{command}' failed: status={p.returncode}")
     value = p.stdout
@@ -59,11 +59,11 @@ def _shell_expand_str(value):
 
 def shell_expand(value):
     if isinstance(value, dict):
-        return dict((k, shell_expand(v)) for k, v in value.items())
+        return {k: shell_expand(v) for k, v in value.items()}
     elif isinstance(value, set):
-        return set(shell_expand(v) for v in value)
+        return {shell_expand(v) for v in value}
     elif isinstance(value, list):
-        return list(shell_expand(v) for v in value)
+        return [shell_expand(v) for v in value]
     elif isinstance(value, tuple):
         return tuple(shell_expand(v) for v in value)
     elif isinstance(value, str):

--- a/core/standalone.py
+++ b/core/standalone.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Core definitions for stand alone pipes invocation."""
-
 import logging
 import sys
 from contextlib import ExitStack
@@ -73,18 +72,18 @@ def help_message(pipe):
         help = help or ""
         if isinstance(node, Pipe.Config):
             if notes is None:
-                notes = "" if default is empty else f"default: {repr(default)}"
+                notes = "" if default is empty else f"default: {default!r}"
             config_entries.append([node.node, type.__name__, help, notes])
         if isinstance(node, Pipe.State):
             if node.node and node.node.startswith("runtime."):
                 continue
             if node.node is not None:
                 if notes is None:
-                    notes = "" if default is empty else f"default: {repr(default)}"
+                    notes = "" if default is empty else f"default: {default!r}"
                 state_entries.append([node.node, type.__name__, help, notes])
             elif indirect := node.get_indirect_node_name():
                 if notes is None:
-                    notes = f"default: {repr(node.node)}"
+                    notes = f"default: {node.node!r}"
                 config_entries.append([indirect, type.__name__, help, notes])
 
     notes = []

--- a/core/util.py
+++ b/core/util.py
@@ -275,7 +275,9 @@ def setup_logging(default_level="NOTSET"):
     return _handler
 
 
-def walk_tree(value, path=[]):
+def walk_tree(value, path=None):
+    if path is None:
+        path = []
     if isinstance(value, Mapping):
         for k, v in value.items():
             yield from walk_tree(v, path + [k])
@@ -289,10 +291,9 @@ def walk_contexts(pipe):
     from . import Pipe
 
     def _walk_ann(ann):
-        if isinstance(ann, type):
-            if issubclass(ann, Pipe.Context):
-                yield ann
-                yield from _walk_context(ann)
+        if isinstance(ann, type) and issubclass(ann, Pipe.Context):
+            yield ann
+            yield from _walk_context(ann)
 
     def _walk_context(ctx):
         for ann in ctx.__annotations__.values():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,11 @@ skip = ["test/venv"]
 [tool.ruff]
 line-length = 140
 exclude = ["test/venv"]
+
+[tool.ruff.lint.per-file-ignores]
+"core/import.py" = ["N999"]
+"core/standalone.py" = ["RUF013"]
+"core/runner.py" = ["FA100"]
+"core/__init__.py" = ["RUF013"]
+"test/test_pipe.py" = ["RUF013"]
+"test/*.py" = ["SIM117"]

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -41,6 +41,7 @@ def run_export(format_, data, *, guess, stdio):
 
     filename = None
     old_stdout = None
+    out_file = None
     suffix = f".{format_}" if format_ else None
     try:
         config = {"node@": "data"}
@@ -51,7 +52,8 @@ def run_export(format_, data, *, guess, stdio):
 
         if stdio:
             old_stdout = sys.stdout
-            sys.stdout = open(filename, "w")
+            out_file = open(filename, "w")  # noqa: SIM115
+            sys.stdout = out_file
         else:
             config["file"] = filename
 
@@ -65,8 +67,8 @@ def run_export(format_, data, *, guess, stdio):
         with open(filename, "r") as f:
             yield deserialize(f, format=format_)
     finally:
-        if old_stdout:
-            sys.stdout.close()
+        if out_file:
+            out_file.close()
             sys.stdout = old_stdout
         if filename:
             os.unlink(filename)

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -44,6 +44,7 @@ def run_import(format_, data, *, guess, stdio, streaming):
 
     filename = None
     old_stdin = None
+    in_file = None
     suffix = f".{format_}" if format_ else None
     try:
         config = {
@@ -58,7 +59,8 @@ def run_import(format_, data, *, guess, stdio, streaming):
 
         if stdio:
             old_stdin = sys.stdin
-            sys.stdin = open(filename, "r")
+            in_file = open(filename, "r")  # noqa: SIM115
+            sys.stdin = in_file
         else:
             config["file"] = filename
 
@@ -68,8 +70,8 @@ def run_import(format_, data, *, guess, stdio, streaming):
         with run("core.import", config, state, in_memory_state=streaming) as state:
             yield state["data"]
     finally:
-        if old_stdin:
-            sys.stdin.close()
+        if in_file:
+            in_file.close()
             sys.stdin = old_stdin
         if filename:
             os.unlink(filename)

--- a/test/test_pipe.py
+++ b/test/test_pipe.py
@@ -96,7 +96,7 @@ def test_config():
     @Pipe("test_config_mutable_default")
     def _(
         pipe: Pipe,
-        name: Annotated[Any, Pipe.Config("name")] = {},
+        name: Annotated[Any, Pipe.Config("name")] = {},  # noqa: B006
     ):
         pass
 
@@ -216,7 +216,7 @@ def test_state():
     @Pipe("test_state_mutable_default")
     def _(
         pipe: Pipe,
-        name: Annotated[dict, Pipe.State("name")] = {},
+        name: Annotated[dict, Pipe.State("name")] = {},  # noqa: B006
     ):
         pass
 

--- a/test/util.py
+++ b/test/util.py
@@ -32,8 +32,8 @@ elif verbosity > 1:
 def run(name, config, state, **kwargs):
     from core.test import run as run_
 
-    with run_(name, config, state, logger, **kwargs) as state:
-        yield state
+    with run_(name, config, state, logger, **kwargs) as result:
+        yield result
 
 
 def TestPipe(fn):


### PR DESCRIPTION
Fix all 46 ruff lint violations reported by `make lint` and the CI failures that the initial fixes introduced.

## Lint fixes
- Apply ruff safe and unsafe auto-fixes: generator/list comprehensions, `setattr`, combined nested `if`s, blind exceptions → `(ValueError, SyntaxError)`, unused imports/variables, `subprocess.run(check=...)`, f-string simplification
- Manual fixes: `walk_tree(path=None)` sentinel, `ClassVar` for `Pipe.__pipes__`, rename shadowed `state` → `result` in test helper
- Make `core/runner.py` and test scripts executable (EXE001)
- Migrate ruff config to the `[tool.ruff.lint]` section

## Rule suppressions
The Pipe framework introspects function annotations at runtime (via `get_args`/`get_type_hints`), so it needs real annotation objects, and typer evaluates annotations on Python 3.8 where PEP 604 unions do not exist. Rewriting `Optional`/`| None` and adding `from __future__ import annotations` broke CI:
- py-3.8: `TypeError: unsupported operand type(s) for |` from typer evaluating `str | None`
- py-3.13: `unknown config nodes` because string annotations return no `Pipe.Config`/`Pipe.State` metadata

Given that, the following are suppressed via per-file-ignores (or inline `noqa`):
- `RUF013` (implicit Optional) in `core/__init__.py`, `core/standalone.py`, `test/test_pipe.py`
- `FA100` (prefer `from __future__ import annotations`) in `core/runner.py`
- `N999` in `core/import.py`, preserving the public `elastic.pipes.core.import` pipe name
- `SIM117` (combined `with`) in test files, where nested `with` is more readable
- `B006` inline for the mutable-default tests, which deliberately verify the framework rejects mutable defaults
- `SIM115` inline where files are bound to `sys.stdout`/`sys.stdin`

Verified: `make lint` green, 80/80 tests pass on Python 3.8 and 3.13, and all `make pkg-test` commands succeed on both.