### PR TITLE
Use `get_type_hints()` instead of `__annotations__`

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -21,7 +21,7 @@ from collections.abc import Mapping, Sequence
 from contextlib import ExitStack
 from typing import ClassVar
 
-from typing_extensions import Annotated, Any, NoDefault, get_args
+from typing_extensions import Annotated, Any, NoDefault, get_args, get_type_hints
 
 from .errors import ConfigError, Error
 from .util import get_node, has_node, is_mutable, set_node
@@ -162,24 +162,29 @@ class Pipe:
         with ExitStack() as stack:
             cc = CommonContext.bind(stack, config, state, core_logger, self.logger)
 
+            try:
+                hints = get_type_hints(self.func, include_extras=True)
+            except NameError as e:
+                raise Error(f"cannot resolve annotations for pipe '{self.name}': {e}") from e
             kwargs = {}
             for name, param in signature(self.func).parameters.items():
                 if name == "dry_run":
                     kwargs["dry_run"] = dry_run
                     continue
-                if isinstance(param.annotation, type):
-                    if issubclass(param.annotation, Pipe):
+                ann = hints.get(name, param.annotation)
+                if isinstance(ann, type):
+                    if issubclass(ann, Pipe):
                         kwargs[name] = self
-                    elif issubclass(param.annotation, logging.Logger):
+                    elif issubclass(ann, logging.Logger):
                         kwargs[name] = self.logger
-                    elif issubclass(param.annotation, ExitStack):
+                    elif issubclass(ann, ExitStack):
                         kwargs[name] = exit_stack
-                    elif issubclass(param.annotation, Pipe.Context):
-                        kwargs[name] = param.annotation.bind(stack, config, state, core_logger, self.logger)
-                    elif issubclass(param.annotation, CommonContext):
+                    elif issubclass(ann, Pipe.Context):
+                        kwargs[name] = ann.bind(stack, config, state, core_logger, self.logger)
+                    elif issubclass(ann, CommonContext):
                         kwargs[name] = cc
                     continue
-                args = get_args(param.annotation)
+                args = get_args(ann)
                 for ann in args:
                     if isinstance(ann, Pipe.Node):
                         param = Pipe.Node.Param(name, args[0], param.default, param.empty)
@@ -211,7 +216,11 @@ class Pipe:
             # define a new sub-type of the user's context
             sub = type(cls.__name__, (cls,), {"logger": pipe_logger})
             bindings = {}
-            for name, ann in cls.__annotations__.items():
+            try:
+                hints = get_type_hints(cls, include_extras=True)
+            except NameError as e:
+                raise Error(f"cannot resolve annotations for context '{cls.__name__}': {e}") from e
+            for name, ann in hints.items():
                 if isinstance(ann, type):
                     if issubclass(ann, Pipe.Context):
                         nested = ann.bind(stack, config, state, core_logger, pipe_logger)

--- a/core/util.py
+++ b/core/util.py
@@ -19,7 +19,7 @@ import re
 import sys
 from collections.abc import Mapping
 
-from typing_extensions import Any, NoDefault, get_args
+from typing_extensions import Any, NoDefault, get_args, get_type_hints
 
 from .errors import ConfigError, Error
 
@@ -296,11 +296,19 @@ def walk_contexts(pipe):
             yield from _walk_context(ann)
 
     def _walk_context(ctx):
-        for ann in ctx.__annotations__.values():
+        try:
+            hints = get_type_hints(ctx, include_extras=True)
+        except NameError as e:
+            raise Error(f"cannot resolve annotations for context '{ctx.__name__}': {e}") from e
+        for ann in hints.values():
             yield from _walk_ann(ann)
 
-    for param in signature(pipe.func).parameters.values():
-        yield from _walk_ann(param.annotation)
+    try:
+        hints = get_type_hints(pipe.func, include_extras=True)
+    except NameError as e:
+        raise Error(f"cannot resolve annotations for pipe '{pipe.name}': {e}") from e
+    for name, param in signature(pipe.func).parameters.items():
+        yield from _walk_ann(hints.get(name, param.annotation))
 
 
 def walk_params(pipe):
@@ -329,14 +337,22 @@ def walk_params(pipe):
             yield node, args[0], help, notes, default, empty
 
     def _walk_context(ctx):
-        for name, ann in ctx.__annotations__.items():
+        try:
+            hints = get_type_hints(ctx, include_extras=True)
+        except NameError as e:
+            raise Error(f"cannot resolve annotations for context '{ctx.__name__}': {e}") from e
+        for name, ann in hints.items():
             default = getattr(ctx, name, NoDefault)
             yield from _walk_ann(ann, default, NoDefault)
 
     yield from _walk_context(CommonContext)
 
-    for param in signature(pipe.func).parameters.values():
-        yield from _walk_ann(param.annotation, param.default, param.empty)
+    try:
+        hints = get_type_hints(pipe.func, include_extras=True)
+    except NameError as e:
+        raise Error(f"cannot resolve annotations for pipe '{pipe.name}': {e}") from e
+    for name, param in signature(pipe.func).parameters.items():
+        yield from _walk_ann(hints.get(name, param.annotation), param.default, param.empty)
 
 
 def walk_config_nodes(pipes, prefix):

--- a/test/test_pipe.py
+++ b/test/test_pipe.py
@@ -17,7 +17,7 @@ from collections.abc import Mapping
 from contextlib import ExitStack
 
 import pytest
-from typing_extensions import Annotated, Any, get_args
+from typing_extensions import Annotated, Any, get_args, get_type_hints
 
 from core import CommonContext, Pipe, get_pipes
 from core.errors import ConfigError, Error
@@ -273,7 +273,7 @@ def test_ctx():
     def _(ctx: TestContext, cc: CommonContext):
         assert ctx.name == "me"
         assert ctx.user == "you"
-        assert "some other annotation" in get_args(ctx.__annotations__["name"])
+        assert "some other annotation" in get_args(get_type_hints(type(ctx), include_extras=True)["name"])
 
     @Pipe("test_ctx_set")
     def _(ctx: TestContext):


### PR DESCRIPTION
Direct `__annotations__` access returns string literals under PEP 563 (`from __future__ import annotations`), causing silent failures: `isinstance`/`issubclass` on strings always returns `False`, so context fields go unbound and pipe parameters go uninjected with no error.

`get_type_hints(..., include_extras=True)` resolves annotations in the defining module's namespace. `include_extras=True` is required to preserve `Annotated` metadata that carries `Pipe.Node` descriptors.