### PR TITLE
Use `getLevelName` to validate `logging.level` config

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -35,7 +35,7 @@ def _indirect(node):
 
 def validate_logging_config(name, config):
     if level := get_node(config, "logging.level", None):
-        level_nr = getattr(logging, level.upper(), None)
+        level_nr = logging.getLevelName(level.upper())
         if not isinstance(level_nr, int):
             raise ConfigError(f"invalid configuration: pipe '{name}': node 'logging.level': value '{level}'")
 


### PR DESCRIPTION
\`getattr(logging, level.upper(), None)\` only works for the standard levels
that logging exposes as module attributes (\`DEBUG\`, \`INFO\`, \`WARNING\`, etc.). It
silently rejects any custom level registered via \`logging.addLevelName\`.

\`logging.getLevelName(name)\` looks up the level in the internal \`_nameToLevel\`
registry instead. It returns the numeric level as an \`int\` for any registered
name, and the string \`"Level <name>"\` for unknown names — so the existing
\`isinstance(level_nr, int)\` guard covers both cases without change.