### PR TITLE
Add TRACE logging level

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -28,6 +28,9 @@ from .util import get_node, has_node, is_mutable, set_node
 
 __version__ = "0.8.0-dev"
 
+TRACE = 5
+logging.addLevelName(TRACE, "TRACE")
+
 
 def _indirect(node):
     return node + "@"


### PR DESCRIPTION
Python's logging module has no TRACE level. Pipes pipelines sometimes need finer-grained visibility than DEBUG, so this adds TRACE at level 5 (the conventional value, one step below DEBUG = 10).

The constant is exported from `elastic.pipes.core` so pipe authors can import it directly:

```python
from elastic.pipes.core import TRACE
```

`addLevelName` registers it with the logging framework, so the existing `validate_logging_config`, `setLevel`, and `setup_logging` code all accept `'trace'` / `'TRACE'` as a valid level string without further changes.